### PR TITLE
[RFC] Only load scripts type javascript

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -95,10 +95,12 @@ export default class extends Controller {
 
   loadScripts (): void {
     this.element.querySelectorAll('script').forEach((content: HTMLScriptElement) => {
-      const script: HTMLScriptElement = document.createElement('script')
-      script.innerHTML = content.innerHTML
+      if (!content.type || content.type.indexOf('script')) {
+        const script: HTMLScriptElement = document.createElement('script')
+        script.innerHTML = content.innerHTML
 
-      document.head.appendChild(script).parentNode.removeChild(script)
+        document.head.appendChild(script).parentNode.removeChild(script)
+      }
     })
   }
 }


### PR DESCRIPTION
RFC

we do have an override of this controller due to returning some html script tag not containing javascript but some other data (json on our side)
ref https://developer.mozilla.org/en-US/docs/Web/HTML/Element/script#embedding_data_in_html

=> thus I propose to add this on the root component, perhaps we can make it configureable also